### PR TITLE
Fix `pint_pandas` dependency error due to update `pint` package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,11 +45,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
         # due to coupledmodeldriver dependency python 3.10 cannot be supported
-        # macos python 3.7 results in segmentation error
-        python-version: [ '3.7', '3.8', '3.9' ]
-        exclude:
-          - os: macos-latest
-            python-version: '3.7'
+        python-version: [ '3.8', '3.9' ]
     steps:
       - name: clone repository
         uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ netcdf4 = '*'
 matplotlib = { version = '*', optional = true }
 numpy = '*'
 pandas = '<1.5.0' # SettingWithCopyWarning issue
+pint = '<0.20' # Import error for quantity from `pint-pandas`
 pint-pandas = '*'
 pyproj = '>=2.6'
 tables = '*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = 'poetry.core.masonry.api'
 enable = true
 
 [tool.poetry.dependencies]
-python = '^3.7'
+python = '^3.8'
 adcircpy = '>=1.1.0'
 appdirs = '*'
 beautifulsoup4 = '*'


### PR DESCRIPTION
`pint` version `0.20.x` have removed `quantity` module, resulting in the following error traceback:
```
>>> import pint_pandas
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "PATH/lib/python3.9/site-packages/pint_pandas/__init__.py", line 3, in <module>                                                                                                           from .pint_array import PintArray, PintType
  File "PATH/lib/python3.9/site-packages/pint_pandas/pint_array.py", line 21, in <module>                                                                                                        from pint.quantity import _Quantity
ModuleNotFoundError: No module named 'pint.quantity'
```