### PR TITLE
Fix/numpy

### DIFF
--- a/ensembleperturbation/plotting/surrogate.py
+++ b/ensembleperturbation/plotting/surrogate.py
@@ -446,7 +446,7 @@ def plot_selected_validations(
         pyplot.subplots_adjust(wspace=0.02, right=0.96)
         cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])
         cbar = figure.colorbar(im, extend='both', cax=cax)
-        cbar.ax.set_title('[m]')  
+        cbar.ax.set_title('[m]')
 
         if output_directory is not None:
             figure.savefig(

--- a/ensembleperturbation/plotting/surrogate.py
+++ b/ensembleperturbation/plotting/surrogate.py
@@ -10,6 +10,7 @@ from matplotlib.axis import Axis
 from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
 import numpy
+from stormevents.nhc import VortexTrack
 import xarray
 
 from ensembleperturbation.plotting.geometry import plot_points, plot_surface
@@ -455,7 +456,10 @@ def plot_selected_validations(
 
 
 def plot_selected_percentiles(
-    node_percentiles: xarray.Dataset, perc_list: list, output_directory: PathLike
+    node_percentiles: xarray.Dataset,
+    perc_list: list,
+    output_directory: PathLike,
+    storm: str = None,
 ):
     percentiles = node_percentiles.quantiles
 
@@ -514,6 +518,20 @@ def plot_selected_percentiles(
 
             map_axis.set_xlim(xlim)
             map_axis.set_ylim(ylim)
+
+            if storm is not None:
+                if not isinstance(storm, VortexTrack):
+                    try:
+                        storm = VortexTrack.from_file(storm)
+                    except FileNotFoundError:
+                        storm = VortexTrack(storm)
+
+                map_axis.plot(
+                    storm.data['longitude'], storm.data['latitude'], 'k--', label=storm.name,
+                )
+
+                if storm.name is not None:
+                    map_axis.legend(fontsize=6)
 
         pyplot.subplots_adjust(wspace=0.02, right=0.96)
         cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])

--- a/ensembleperturbation/plotting/surrogate.py
+++ b/ensembleperturbation/plotting/surrogate.py
@@ -446,6 +446,7 @@ def plot_selected_validations(
         pyplot.subplots_adjust(wspace=0.02, right=0.96)
         cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])
         cbar = figure.colorbar(im, extend='both', cax=cax)
+        cbar.ax.set_title('[m]')  
 
         if output_directory is not None:
             figure.savefig(
@@ -517,6 +518,7 @@ def plot_selected_percentiles(
         pyplot.subplots_adjust(wspace=0.02, right=0.96)
         cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])
         cbar = figure.colorbar(im, extend='both', cax=cax)
+        cbar.ax.set_title('[m]')
 
         if output_directory is not None:
             figure.savefig(

--- a/ensembleperturbation/plotting/surrogate.py
+++ b/ensembleperturbation/plotting/surrogate.py
@@ -400,7 +400,7 @@ def plot_selected_validations(
             validation['y'].max(),
         ]
     )
-    vmax = numpy.round_(validation.sel(source='model').results.quantile(0.98), decimals=1)
+    vmax = numpy.round(validation.sel(source='model').results.quantile(0.98), decimals=1)
     vmin = 0.0
     for run in run_list:
         figure = pyplot.figure()
@@ -476,7 +476,7 @@ def plot_selected_percentiles(
             node_percentiles['y'].max(),
         ]
     )
-    vmax = numpy.round_(percentiles.sel(source='model').quantile(0.98), decimals=1)
+    vmax = numpy.round(percentiles.sel(source='model').quantile(0.98), decimals=1)
     vmin = 0.0
     for perc in perc_list:
         figure = pyplot.figure()

--- a/ensembleperturbation/plotting/surrogate.py
+++ b/ensembleperturbation/plotting/surrogate.py
@@ -594,6 +594,7 @@ def plot_selected_probability_fields(
     output_directory: PathLike,
     label_unit_convert_factor: float = 1,
     label_unit_name: str = 'm',
+    storm: str = None,
 ):
     probabilities = node_prob_field.probabilities
 
@@ -654,6 +655,20 @@ def plot_selected_probability_fields(
 
             map_axis.set_xlim(xlim)
             map_axis.set_ylim(ylim)
+
+            if storm is not None:
+                if not isinstance(storm, VortexTrack):
+                    try:
+                        storm = VortexTrack.from_file(storm)
+                    except FileNotFoundError:
+                        storm = VortexTrack(storm)
+
+                map_axis.plot(
+                    storm.data['longitude'], storm.data['latitude'], 'k--', label=storm.name,
+                )
+
+                if storm.name is not None:
+                    map_axis.legend(fontsize=6)
 
         pyplot.subplots_adjust(wspace=0.02, right=0.96)
         cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])

--- a/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
+++ b/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
@@ -162,6 +162,7 @@ def karhunen_loeve_prediction(
     actual_values=None,
     ensembles_to_plot=None,
     element_table=None,
+    reference_line: bool = True,
     plot_directory: PathLike = None,
 ):
     """
@@ -194,6 +195,9 @@ def karhunen_loeve_prediction(
         ylim = axis.get_ylim()
         axis.set_xlim(min(xlim[0], ylim[0]), max(xlim[1], ylim[1]))
         axis.set_ylim(min(xlim[0], ylim[0]), max(xlim[1], ylim[1]))
+
+        if reference_line:
+            axis.plot([xlim[0],ylim[0]],[xlim[1],ylim[1]], '--k', alpha=0.3)
 
         figure.savefig(
             plot_directory / f'KL_fit.png', dpi=200, bbox_inches='tight',

--- a/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
+++ b/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
@@ -266,6 +266,7 @@ def karhunen_loeve_prediction(
             pyplot.subplots_adjust(wspace=0.02, right=0.96)
             cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])
             cbar = figure.colorbar(im, extend='both', cax=cax)
+            cbar.ax.set_title('[m]')   
 
             figure.savefig(
                 plot_directory / f'KL_ensemble{example}.png', dpi=200, bbox_inches='tight',

--- a/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
+++ b/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
@@ -193,11 +193,13 @@ def karhunen_loeve_prediction(
 
         xlim = axis.get_xlim()
         ylim = axis.get_ylim()
-        axis.set_xlim(min(xlim[0], ylim[0]), max(xlim[1], ylim[1]))
-        axis.set_ylim(min(xlim[0], ylim[0]), max(xlim[1], ylim[1]))
-
+        bb_min = min(xlim[0], ylim[0])
+        bb_max = max(xlim[1], ylim[1])
+        axis.set_xlim(bb_min, bb_max)
+        axis.set_ylim(bb_min, bb_max)         
+          
         if reference_line:
-            axis.plot([xlim[0],ylim[0]],[xlim[1],ylim[1]], '--k', alpha=0.3)
+            axis.plot([bb_min,bb_max],[bb_min,bb_max], '--k', alpha=0.3, zorder=-50)
 
         figure.savefig(
             plot_directory / f'KL_fit.png', dpi=200, bbox_inches='tight',

--- a/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
+++ b/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
@@ -214,8 +214,8 @@ def karhunen_loeve_prediction(
                 actual_values['y'].max(),
             ]
         )
-        vmax = np.round_(actual_values.quantile(0.98), decimals=1)
-        vmin = min(0.0, np.round_(actual_values.quantile(0.02), decimals=1))
+        vmax = np.round(actual_values.quantile(0.98), decimals=1)
+        vmin = min(0.0, np.round(actual_values.quantile(0.02), decimals=1))
         sources = {'actual': actual_values, 'reconstructed': kl_prediction}
         map_crs = cartopy.crs.PlateCarree()
         for example in ensembles_to_plot:

--- a/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
+++ b/ensembleperturbation/uncertainty_quantification/karhunen_loeve_expansion.py
@@ -196,10 +196,10 @@ def karhunen_loeve_prediction(
         bb_min = min(xlim[0], ylim[0])
         bb_max = max(xlim[1], ylim[1])
         axis.set_xlim(bb_min, bb_max)
-        axis.set_ylim(bb_min, bb_max)         
-          
+        axis.set_ylim(bb_min, bb_max)
+
         if reference_line:
-            axis.plot([bb_min,bb_max],[bb_min,bb_max], '--k', alpha=0.3, zorder=-50)
+            axis.plot([bb_min, bb_max], [bb_min, bb_max], '--k', alpha=0.3, zorder=-50)
 
         figure.savefig(
             plot_directory / f'KL_fit.png', dpi=200, bbox_inches='tight',
@@ -266,7 +266,7 @@ def karhunen_loeve_prediction(
             pyplot.subplots_adjust(wspace=0.02, right=0.96)
             cax = pyplot.axes([0.95, 0.55, 0.015, 0.3])
             cbar = figure.colorbar(im, extend='both', cax=cax)
-            cbar.ax.set_title('[m]')   
+            cbar.ax.set_title('[m]')
 
             figure.savefig(
                 plot_directory / f'KL_ensemble{example}.png', dpi=200, bbox_inches='tight',


### PR DESCRIPTION
I replaced `round_` with `round` in `surrogate.py` and `karhunen_loeve_expansion.py` to address the following warning:

```
DeprecationWarning: `round_` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `round` instead.
```

I tested it locally and it worked fine! 

@SorooshMani-NOAA would you confirm making this merge?